### PR TITLE
Limit cache size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,11 +49,10 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backy-extract"
-version = "0.3.2"
+version = "0.3.3-dev"
 dependencies = [
  "anyhow",
  "atty",
- "bitvec",
  "byteorder",
  "chrono",
  "clap",
@@ -92,18 +91,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470fbd40e959c961f16841fbf96edbbdcff766ead89a1ae2b53d22852be20998"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "byteorder"
@@ -318,12 +305,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "fuse"
@@ -592,12 +573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
-
-[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,12 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,12 +990,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,7 +55,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backy-extract"
-version = "0.3.3-dev"
+version = "1.0.0-dev"
 dependencies = [
  "anyhow",
  "atty",
@@ -64,9 +70,11 @@ dependencies = [
  "fs2",
  "fuse",
  "indicatif",
+ "jemallocator",
  "lazy_static",
  "libc",
  "log 0.4.14",
+ "lru",
  "maplit",
  "memmap",
  "minilzo",
@@ -97,6 +105,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -301,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +348,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -376,6 +405,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backy-extract"
-version = "0.3.2-beta"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backy-extract"
-version = "0.3.2"
+version = "0.3.3-dev"
 authors = ["Christian Kauhaus <christian@kauhaus.de>"]
 edition = "2018"
 description = "Rapid restore tool for backy"
@@ -10,7 +10,6 @@ repository = "https://github.com/flyingcircusio/backy-extract"
 [dependencies]
 anyhow = "1"
 atty = "0.2"
-bitvec = "0.21"
 byteorder = "1.2"
 chrono = "0.4"
 clap = { version = "2.32", features = ["wrap_help"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backy-extract"
-version = "0.3.3-dev"
+version = "1.0.0-dev"
 authors = ["Christian Kauhaus <christian@kauhaus.de>"]
 edition = "2018"
 description = "Rapid restore tool for backy"
@@ -20,9 +20,11 @@ fnv = "1"
 fs2 = "0.4"
 fuse = { version = "0.3", optional = true }
 indicatif = "0.13"
+jemallocator = "0.3"
 lazy_static = "1.2"
 libc = "0.2"
 log = "0.4"
+lru = "0.6.5"
 memmap = "0.7"
 minilzo = "0.2"
 num_cpus = "1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backy-extract"
-version = "0.3.2-beta"
+version = "0.3.2"
 authors = ["Christian Kauhaus <christian@kauhaus.de>"]
 edition = "2018"
 description = "Rapid restore tool for backy"

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-05-15  Christian Kauhaus <christian@kauhaus.de>
+
+	* Release backy-extract 1.0.0
+	* Rework FUSE caching.
+	* Add `-c`/`--cache` option
+	* Rework README and man page
+
 2021-05-04  Christian Kauhaus <christian@kauhaus.de>
 
 	* Release backy-extract 0.3.2

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-05-04  Christian Kauhaus <christian@kauhaus.de>
+
+	* Release backy-extract 0.3.2
+
 2021-05-01  Christian Kauhaus <christian@kauhaus.de>
 
 	* Fix read errors with FUSE driver.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ backy-extract
 =============
 
 High-performance, standalone backup restore tool for
-[backy](https://bitbucket.org/flyingcircus/backy). backy-extract restores a
+[backy](https://github.com/flyingcircusio/backy). backy-extract restores a
 specified backup revision to stdout or a file/block device target.
 
 

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   name = "backy-extract";
-  version = "0.3.2-beta";
+  version = "0.3.2";
 
   src = lib.cleanSourceWith {
     filter = n: t: (excludeTarget n t) && (lib.cleanSourceFilter n t);
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     fi
   '';
 
-  cargoSha256 = "0rmga1axx8i04n68vwlwgpvis818smjpkvdwgaxdx122lc600l8c";
+  cargoSha256 = "1bk6cy0qm0j2wr7qld08gjgmmsvnbz15ifk3ivms9xkhzlfhrz3v";
   cargoBuildFlags = lib.optionals stdenv.isLinux [ "--features fuse_driver" ];
 
   meta = with lib; {

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   name = "backy-extract";
-  version = "0.3.2";
+  version = "0.3.3-dev";
 
   src = lib.cleanSourceWith {
     filter = n: t: (excludeTarget n t) && (lib.cleanSourceFilter n t);
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     fi
   '';
 
-  cargoSha256 = "1bk6cy0qm0j2wr7qld08gjgmmsvnbz15ifk3ivms9xkhzlfhrz3v";
+  cargoSha256 = "0h6bwh6ii4hd13gcxxs1n3ib7ahrfk8yhhigwrb1dahh4niv351q";
   cargoBuildFlags = lib.optionals stdenv.isLinux [ "--features fuse_driver" ];
 
   meta = with lib; {

--- a/default.nix
+++ b/default.nix
@@ -2,11 +2,11 @@
 , pkgs ? import <nixpkgs> {}
 , stdenv ? pkgs.stdenv
 , lib ? pkgs.lib
-, lzo ? pkgs.lzo
-, fuse ? pkgs.fuse
-, pkgconfig ? pkgs.pkgconfig
 , docutils ? pkgs.docutils
+, fuse ? pkgs.fuse
 , jq ? pkgs.jq
+, lzo ? pkgs.lzo
+, pkgconfig ? pkgs.pkgconfig
 , rustPlatform ? pkgs.rustPlatform
 , Security ? pkgs.darwin.apple_sdk.frameworks.Security
 }:
@@ -19,7 +19,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   name = "backy-extract";
-  version = "0.3.3-dev";
+  version = "1.0.0-dev";
 
   src = lib.cleanSourceWith {
     filter = n: t: (excludeTarget n t) && (lib.cleanSourceFilter n t);
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs =
     [ lzo ] ++
     (lib.optionals stdenv.isDarwin [ Security ]) ++
-    (lib.optionals stdenv.isLinux [ pkgconfig fuse ]);
+    (lib.optionals stdenv.isLinux [ fuse ]);
 
   preConfigure = ''
     if ! cargo read-manifest | jq .version -r | grep -q $version; then
@@ -40,8 +40,22 @@ rustPlatform.buildRustPackage rec {
     fi
   '';
 
-  cargoSha256 = "0h6bwh6ii4hd13gcxxs1n3ib7ahrfk8yhhigwrb1dahh4niv351q";
+  cargoSha256 = "0kfqdhk4n2rfks36pflck79dv4r0x51hz3jny3kgdbbdnnymm3rz";
   cargoBuildFlags = lib.optionals stdenv.isLinux [ "--features fuse_driver" ];
+  checkType = "debug";
+
+  postPatch = ''
+    substituteAllInPlace man/*.rst
+  '';
+
+  postBuild = ''
+    mkdir -p $out/share/doc $out/share/man/man1
+    cp README.md $out/share/doc
+    for f in man/*.1.rst; do
+      base="''${f#*/}"
+      rst2man $f > "$out/share/man/man1/''${base%%.rst}"
+    done
+  '';
 
   meta = with lib; {
     description = "Rapid restore tool for backy";
@@ -49,18 +63,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ maintainers.ckauhaus ];
     platforms = platforms.unix;
   };
-
-  postPatch = ''
-    substituteAllInPlace man/*.rst
-  '';
-
-  postBuild = ''
-    mkdir -p $out/share/doc
-    cp README.md $out/share/doc
-
-    mkdir -p $out/share/man/man1
-    for f in $man/*.1.rst; do
-      rst2man $f > $out/share/man/man1/''${f%%.rst}
-    done
-  '';
 }

--- a/man/backy-fuse.1.rst
+++ b/man/backy-fuse.1.rst
@@ -6,7 +6,7 @@ backy-fuse
 export backy images via filesystem in userspace (FUSE)
 ------------------------------------------------------
 
-:Author: Christian Kauhaus <kc@flyingcircus.io>
+:Author: Christian Kauhaus <christian@kauhaus.de>
 :Version: @version@
 :Manual section: 1
 :Manual group: User commands
@@ -22,9 +22,10 @@ DESCRIPTION
 ===========
 
 Provide access to all backy backup images of a source via a virtual filesystem.
-They can be loop-mounted to retrieve individual files from backups. Each revision found will be
-exported as individual image. Images are made accessible in read-write mode, but modifications
-are never written to the underlying chunk store.
+They can be loop-mounted to retrieve individual files from backups. Each
+revision found will be exported as individual image. Images are made accessible
+in read-write mode, but modifications are never written to the underlying chunk
+store.
 
 See **Examples** below for a restore walk-through.
 
@@ -36,9 +37,10 @@ OPTIONS
     Backy data directory containing `*.rev` files.
 
 **-o** *MOUNTOPTS*, **--mountopts** *MOUNTOPTS*
-    Additional options to pass to the underlying **mount(8)** invocation. Defaults to
-    **allow_root** which lifts the restriction that the superuser is normally unable to access
-    FUSE filesystems. See **fuse(8)** for a list of allowed options.
+    Additional options to pass to the underlying **mount(8)** invocation.
+    Defaults to **allow_root** which lifts the restriction that the superuser is
+    normally unable to access FUSE filesystems. See **fuse(8)** for a list of
+    allowed options.
 
 **-V**, **--version**
     Show version.
@@ -50,32 +52,34 @@ OPTIONS
 EXIT STATUS
 ===========
 
-Please note that backy-fuse runs as long as the filesystem is mounted. Use **fusermount -u**
-*MOUNTPOINT* to unmount the filesystem recovery has been finished.
+Please note that backy-fuse runs as long as the filesystem is mounted. Use
+**fusermount -u** *MOUNTPOINT* to unmount the filesystem recovery has been
+finished.
 
 0
     FUSE filesystem has been mounted and unmounted successfully.
 1
     Backup directory could not be locked or revision list could not be initialized.
 
-backy-fuse does not exit on I/O error but reports them through the mounted filesystem.
+backy-fuse does not exit on I/O error but reports them through the mounted
+filesystem.
 
 
 ENVIRONMENT
 ===========
 
 RUST_LOG
-    Enable additional logging to stderr. Set to **info** or **debug** to increase level of
-    verbosity.
+    Enable additional logging to stderr. Set to **info** or **debug** to
+    increase level of verbosity.
 
 
 FILES
 =====
 
 /etc/fuse.conf
-    Must contain **user_allow_other** so that the FUSE filesystem can be mounted with the
-    default **allow_root** option. Invoke backy-fuse with **-o ""** if that setting is not
-    available.
+    Must contain **user_allow_other** so that the FUSE filesystem can be mounted
+    with the default **allow_root** option. Invoke backy-fuse with **-o ""** if
+    that setting is not available.
 
 
 EXAMPLE
@@ -96,7 +100,7 @@ Then explore or copy images from a second terminal::
 
 Don't forget to unmount the FUSE filesystem when finished::
 
-    $ fusermount u /mnt/backy
+    $ fusermount -u /mnt/backy
 
 
 2. Restore files
@@ -106,8 +110,8 @@ Mount backup images::
 
     $ backy-fuse -d /srv/backy/testvm /mnt/backy-fuse
 
-Select revision to restore from. In this example, we will be restoring from revision
-`tAGKE5rrxReggVMtoPSr7`.
+Select revision to restore from. In this example, we will be restoring from
+revision `tAGKE5rrxReggVMtoPSr7`.
 
 Set up loop device to access partitions inside the image::
 
@@ -116,7 +120,7 @@ Set up loop device to access partitions inside the image::
 
 Loop mount the image::
 
-    # mount -oloop /dev/loop0p1 /mnt/restore
+    # mount -oro /dev/loop0p1 /mnt/restore
 
 If the image does not contain a partition table, use `/dev/loop0` instead of
 `/dev/loop0p1` for example.
@@ -134,9 +138,18 @@ Finally, unmount the FUSE filesystem::
     $ fusermount -u /mnt/backy-fuse
 
 
+NOTES
+=====
+
+backy-fuse employs a two-tier cache scheme. Chunks are kept in a fixed-size read
+only cache (256 MiB large by default). In case backup images are written to,
+dirty pages are copied into an unbounded page cache which is kept in memory as
+long as backy-fuse is running. So avoid read-write mounts of backup images.
+
+
 SEE ALSO
 ========
 
 fuse(8), mount(8), fusermount(1)
 
-https://bitbucket.org/flyingcircus/backy
+https://github.com/flyingcircusio/backy

--- a/src/backend/rev.rs
+++ b/src/backend/rev.rs
@@ -1,0 +1,82 @@
+//! Rev files (*.rev) contain additional information to the chunk map
+
+use chrono::{DateTime, TimeZone, Utc};
+use serde::{Deserialize, Deserializer};
+use smallstr::SmallString;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("I/O error")]
+    Io(#[from] io::Error),
+    #[error("Invalid data in .rev file '{}'", path.display())]
+    ParseRev {
+        path: PathBuf,
+        source: serde_yaml::Error,
+    },
+    #[error("Unknown backend_type '{}' found in {}", betype, path.display())]
+    WrongType { betype: String, path: PathBuf },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub type RevId = SmallString<[u8; 24]>;
+
+fn revid_de<'de, D>(deserializer: D) -> Result<RevId, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(RevId::from(String::deserialize(deserializer)?))
+}
+
+static TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.f%z";
+fn timestamp_de<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Utc.datetime_from_str(&String::deserialize(deserializer)?, TIMESTAMP_FORMAT)
+        .map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RevStats {
+    pub bytes_written: u64,
+    pub duration: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Rev {
+    pub backend_type: String,
+    #[serde(deserialize_with = "revid_de")]
+    pub parent: RevId,
+    pub stats: RevStats,
+    #[serde(deserialize_with = "timestamp_de")]
+    pub timestamp: DateTime<Utc>,
+    pub trust: String,
+    #[serde(deserialize_with = "revid_de")]
+    pub uuid: RevId,
+}
+
+impl Rev {
+    pub fn load<P: AsRef<Path>, I: AsRef<str>>(dir: P, id: I) -> Result<Self> {
+        let map = dir.as_ref().join(id.as_ref());
+        let rev = map.with_extension("rev");
+        let r: Self =
+            serde_yaml::from_reader(fs::File::open(&rev)?).map_err(|source| Error::ParseRev {
+                path: rev.to_path_buf(),
+                source,
+            })?;
+        if r.backend_type != "chunked" {
+            return Err(Error::WrongType {
+                betype: r.backend_type,
+                path: rev,
+            });
+        }
+        Ok(r)
+    }
+}
+
+// see src/fuse/access.rb for tests

--- a/src/writeout/randomaccess.rs
+++ b/src/writeout/randomaccess.rs
@@ -67,7 +67,7 @@ impl RandomWriteOut {
         if self.size <= 2 << CHUNKSZ_LOG {
             return Ok(false);
         }
-        let mut buf = vec![0; CHUNKSZ as usize];
+        let mut buf = vec![0; CHUNKSZ];
         let mut dev = File::open(&self.path)?;
         for chunk in RandomSample::new(pos2chunk(self.size)) {
             dev.seek(io::SeekFrom::Start(chunk2pos(chunk)))?;

--- a/src/writeout/stream.rs
+++ b/src/writeout/stream.rs
@@ -37,7 +37,7 @@ impl<W: Write + Send + Sync> Stream<W> {
                 Data::Zero => &ZERO_CHUNK,
             })
             .map_err(|e| Error::WriteChunk(seq, e))?;
-        progress.send(CHUNKSZ as usize)?;
+        progress.send(CHUNKSZ)?;
         Ok(())
     }
 }
@@ -121,7 +121,7 @@ mod tests {
     use lazy_static::lazy_static;
     use smallvec::smallvec;
 
-    const CS: usize = CHUNKSZ as usize;
+    const CS: usize = CHUNKSZ;
 
     lazy_static! {
         static ref CHUNKS: Vec<Vec<u8>> = vec![vec![0; CS], vec![1; CS], vec![2; CS], vec![3; CS]];

--- a/tests/fuse.rs
+++ b/tests/fuse.rs
@@ -44,6 +44,7 @@ impl FuseMount {
                 basedir,
                 mountopts: Vec::new(),
                 mountpoint,
+                ..Default::default()
             }
             .run()
             .unwrap();


### PR DESCRIPTION
We now maintain two caches: One (ro_cache) as LRU read-only cache to avoid repeated decompression of pages. This other (dirty) is a traditional HashMap which caches dirty pages indefinitely.

The size of the LRU cache is statically limited (default: 256MiB) while the dirty page cache could grow up to the size of the underlying image if all pages were written to. We assume that this is not a normal use case since the purpose of backy-fuse is to retrieve single files from backup images.

Thus, it is adivable to mount backy images read-only. Note that even in this case a limited amount of write operations will take place, e.g. to update the filesystem's mounted flag.

Re #7