### PR TITLE
re-lock cargoHash for fetchCargoVendor in NixOS 25.05

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     fi
   '';
 
-  cargoHash = "sha256-fbm0jYQWb7WG/yMH4OCNMMc2EXuH2KG+7vUa/jDwUjU=";
+  cargoHash = "sha256-vf3AYpP7nM/lmzrOgFI31Obox4d0+bbiPvlOHyDQEEs=";
   cargoBuildFlags = lib.optionals stdenv.isLinux [ "--features fuse_driver" ];
   checkType = "debug";
 


### PR DESCRIPTION
from the NixOS 25.05 release notes:

> Cargo 1.84.0 changed the format of cargo vendor output, which invalidated all existing rustPlatform.fetchCargoTarball hashes. To preserve Nix’s invariants, it has been replaced with rustPlatform.fetchCargoVendor, an independent implementation prioritizing format stability. rustPlatform.buildRustPackage now uses rustPlatform.fetchCargoVendor by default; a hash mismatch error is expected in third‐party Rust packages when updating to Nixpkgs 25.05.